### PR TITLE
Add initial IOReader implementation

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -8,4 +8,4 @@
   :dependencies ["https://github.com/pyrmont/testament"])
 
 (declare-source
-  :source ["src/bencodobi" "src/bencodobi.janet"])
+  :source ["src/bencodobi" "src/bencodobi.janet" "src/iostream.janet"])

--- a/src/bencodobi/decoder.janet
+++ b/src/bencodobi/decoder.janet
@@ -1,12 +1,12 @@
 (import ../iostream :as io)
 
 
-(def single (buffer/new 1))
-(def multi (buffer/new 1))
+(def- single (buffer/new 1))
+(def- multi (buffer/new 1))
 
 
 # Forward declaration
-(varfn decode [stream &opt indicator])
+(varfn decode [input &opt indicator])
 
 
 (defn- read-byte

--- a/src/bencodobi/decoder.janet
+++ b/src/bencodobi/decoder.janet
@@ -1,3 +1,6 @@
+(import ../iostream :as io)
+
+
 (def single (buffer/new 1))
 (def multi (buffer/new 1))
 
@@ -119,12 +122,13 @@
 
 
 (varfn decode
-  "Decode a bytestream `stream`
+  "Decode `input`
 
   This function is possibly called by the list and dictionary decoding functions
   and so can be passed an initial `indicator`."
-  [stream &opt indicator]
-  (let [byte (or indicator (read-byte stream))]
+  [input &opt indicator]
+  (let [stream (io/reader input)
+        byte   (or indicator (read-byte stream))]
     (cond
       (is-num? byte)      (->> (decode-nums stream ":" (to-digit byte))
                                (decode-str stream))

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -11,8 +11,9 @@
 
 (defn read-from-string
   (str num-bytes buf start)
-  (let [buf-len (length buf)]
-    (buffer/blit buf (string/slice str num-bytes start) buf-len)))
+  (let [buf-len (length buf)
+        to-copy (string/slice str start (+ start num-bytes))]
+    (buffer/blit buf to-copy buf-len)))
 
 
 (def IOStream
@@ -29,6 +30,8 @@
               (read-from-buffer (self :source) num-bytes buf (self :curr))
 
               :string
-              (read-from-string (self :source) num-bytes buf (self :curr)))
+              (read-from-string (self :source) num-bytes buf (self :curr))
+
+              (break (:read (self :source) num-bytes buf)))
             (put self :curr (+ (self :curr) num-bytes))
             buf)})

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -49,6 +49,12 @@
 
 
 (defn reader
+  ```
+  Wrap `source` in an `IOReader` unless it is already wrapped
+
+  The IOReader prototype is a stream reading abstraction that allows objects
+  to respond to a `:read` function call"
+  ```
   [source]
   (if (and (= :table (type source)) (= IOReader (table/getproto source)))
     source

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -53,7 +53,7 @@
   Wrap `source` in an `IOReader` unless it is already wrapped
 
   The IOReader prototype is a stream reading abstraction that allows objects
-  to respond to a `:read` function call"
+  to respond to a `:read` function call".
   ```
   [source]
   (if (and (= :table (type source)) (= IOReader (table/getproto source)))

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -48,7 +48,7 @@
             buf)})
 
 
-(defn stream
+(defn reader
   [source]
   (if (and (= :table (type source)) (= IOReader (table/getproto source)))
     source

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -32,7 +32,7 @@
     (buffer/blit buf (string/slice str start end) buf-len)))
 
 
-(def- IOStream
+(def- IOReader
   @{:source @""
     :curr 0
     :read (fn [self num-bytes buf]
@@ -50,6 +50,6 @@
 
 (defn stream
   [source]
-  (if (get source :read)
+  (if (and (= :table (type source)) (= IOReader (table/getproto source)))
     source
-    (table/setproto @{:source source} IOStream)))
+    (table/setproto @{:source source} IOReader)))

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -1,0 +1,34 @@
+(defn read-from-buffer
+  [in-buf num-bytes out-buf start]
+  (let [out-len (length out-buf)]
+    (buffer/blit out-buf in-buf out-len start num-bytes)))
+
+
+(defn read-from-file
+  [file num-bytes buf]
+  (file/read file num-bytes buf))
+
+
+(defn read-from-string
+  (str num-bytes buf start)
+  (let [buf-len (length buf)]
+    (buffer/blit buf (string/slice str num-bytes start) buf-len)))
+
+
+(def IOStream
+  @{:source @""
+    :curr 0
+    :read (fn [self num-bytes buf]
+            (if (> (+ num-bytes (self :curr)) (length (self :source)))
+              (error "more bytes requested than in stream"))
+            (case (type (self :source))
+              :core/file
+              (read-from-file (self :source) num-bytes buf)
+
+              :buffer
+              (read-from-buffer (self :source) num-bytes buf (self :curr))
+
+              :string
+              (read-from-string (self :source) num-bytes buf (self :curr)))
+            (put self :curr (+ (self :curr) num-bytes))
+            buf)})

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -11,9 +11,8 @@
 
 (defn read-from-string
   (str num-bytes buf start)
-  (let [buf-len (length buf)
-        to-copy (string/slice str start (+ start num-bytes))]
-    (buffer/blit buf to-copy buf-len)))
+  (let [buf-len (length buf)]
+    (buffer/blit buf (string/slice str start (+ start num-bytes)) buf-len)))
 
 
 (def IOStream

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -1,30 +1,46 @@
-(defn read-from-buffer
+(def- error-message
+  "more bytes requrested than in stream")
+
+
+(defn- read-from-buffer
+  ```
+  Copy `num-bytes` from `in-buf` to `out-buf` beginning at `start`
+
+  This function may return less than `num-bytes` if more bytes are requested
+  than are left in the buffer.
+  ```
   [in-buf num-bytes out-buf start]
-  (let [out-len (length out-buf)]
-    (buffer/blit out-buf in-buf out-len start num-bytes)))
+  # (if (> (+ num-bytes start) (length in-buf))
+  #   (error error-message))
+  (let [in-len   (length in-buf)
+        out-len  (length out-buf)
+        copy-len (if (> (+ num-bytes start) in-len)
+                   (- in-len start) num-bytes)]
+    (buffer/blit out-buf in-buf out-len start copy-len)))
 
 
-(defn read-from-file
-  [file num-bytes buf]
-  (file/read file num-bytes buf))
+(defn- read-from-string
+  ```
+  Copy `num-bytes` from `str` to `buf` beginning at `start`
+
+  This function may return less than `num-bytes` if more bytes are requested
+  than are left in the string.
+  ```
+  [str num-bytes buf start]
+  # (if (> (+ num-bytes start) (length str))
+  #   (error error-message))
+  (let [str-len  (length str)
+        buf-len  (length buf)
+        copy-len (if (> (+ num-bytes start) str-len)
+                   (- str-len start) num-bytes)]
+    (buffer/blit buf (string/slice str start (+ start copy-len)) buf-len)))
 
 
-(defn read-from-string
-  (str num-bytes buf start)
-  (let [buf-len (length buf)]
-    (buffer/blit buf (string/slice str start (+ start num-bytes)) buf-len)))
-
-
-(def IOStream
+(def- IOStream
   @{:source @""
     :curr 0
     :read (fn [self num-bytes buf]
-            (if (> (+ num-bytes (self :curr)) (length (self :source)))
-              (error "more bytes requested than in stream"))
             (case (type (self :source))
-              :core/file
-              (read-from-file (self :source) num-bytes buf)
-
               :buffer
               (read-from-buffer (self :source) num-bytes buf (self :curr))
 
@@ -34,3 +50,8 @@
               (break (:read (self :source) num-bytes buf)))
             (put self :curr (+ (self :curr) num-bytes))
             buf)})
+
+
+(defn stream
+  [source]
+  (table/setproto @{:source source} IOStream))

--- a/src/iostream.janet
+++ b/src/iostream.janet
@@ -10,13 +10,11 @@
   than are left in the buffer.
   ```
   [in-buf num-bytes out-buf start]
-  # (if (> (+ num-bytes start) (length in-buf))
-  #   (error error-message))
-  (let [in-len   (length in-buf)
-        out-len  (length out-buf)
-        copy-len (if (> (+ num-bytes start) in-len)
-                   (- in-len start) num-bytes)]
-    (buffer/blit out-buf in-buf out-len start copy-len)))
+  (let [in-len  (length in-buf)
+        out-len (length out-buf)
+        end     (if (> (+ num-bytes start) in-len)
+                   (- in-len start) (+ num-bytes start))]
+    (buffer/blit out-buf in-buf out-len start end)))
 
 
 (defn- read-from-string
@@ -27,13 +25,11 @@
   than are left in the string.
   ```
   [str num-bytes buf start]
-  # (if (> (+ num-bytes start) (length str))
-  #   (error error-message))
-  (let [str-len  (length str)
-        buf-len  (length buf)
-        copy-len (if (> (+ num-bytes start) str-len)
-                   (- str-len start) num-bytes)]
-    (buffer/blit buf (string/slice str start (+ start copy-len)) buf-len)))
+  (let [str-len (length str)
+        buf-len (length buf)
+        end     (if (> (+ num-bytes start) str-len)
+                  (- str-len start) (+ num-bytes start))]
+    (buffer/blit buf (string/slice str start end) buf-len)))
 
 
 (def- IOStream
@@ -54,4 +50,6 @@
 
 (defn stream
   [source]
-  (table/setproto @{:source source} IOStream))
+  (if (get source :read)
+    source
+    (table/setproto @{:source source} IOStream)))

--- a/test/decoder.janet
+++ b/test/decoder.janet
@@ -2,57 +2,48 @@
 (import ../src/bencodobi :as bencodobi)
 
 
-(def- Stream
-  @{:content @""
-    :read (fn [self num_bytes buf]
-            (let [taken (buffer/slice (self :content) 0 num_bytes)
-                  left  (buffer/slice (self :content) num_bytes)]
-              (put self :content left)
-              (buffer/push-string buf (string taken))))})
-
-
 (deftest decode-ascii-string
-  (def an-ascii-str (table/setproto @{:content @"4:spam"} Stream))
+  (def an-ascii-str @"4:spam")
   (is (= "spam" (bencodobi/decode an-ascii-str)) "decode an ASCII string"))
 
 
 (deftest decode-utf8-string
-  (def a-utf8-str (table/setproto @{:content @"4:👍"} Stream))
+  (def a-utf8-str @"4:👍")
   (is (= "👍" (bencodobi/decode a-utf8-str)) "decode a UTF-8 string"))
 
 
 (deftest decode-integer
-  (def an-int (table/setproto @{:content @"i42e"} Stream))
+  (def an-int @"i42e")
   (is (= 42 (bencodobi/decode an-int)) "decode an integer"))
 
 
 (deftest decode-negative-integer
-  (def an-int (table/setproto @{:content @"i-42e"} Stream))
+  (def an-int @"i-42e")
   (is (= -42 (bencodobi/decode an-int)) "decode a negative integer"))
 
 
 (deftest decode-empty-list
-  (def an-empty-list (table/setproto @{:content @"le"} Stream))
+  (def an-empty-list @"le")
   (is (= [] (bencodobi/decode an-empty-list)) "decode an empty list"))
 
 
 (deftest decode-list
-  (def a-list (table/setproto @{:content @"l4:spami42ee"} Stream))
+  (def a-list @"l4:spami42ee")
   (is (= ["spam" 42] (bencodobi/decode a-list)) "decode a list"))
 
 
 (deftest decode-empty-dict
-  (def an-empty-dict (table/setproto @{:content @"de"} Stream))
+  (def an-empty-dict @"de")
   (is (= {} (bencodobi/decode an-empty-dict)) "decode an empty dictionary"))
 
 
 (deftest decode-dict
- (def a-dict (table/setproto @{:content @"d3:cow3:moo4:spam4:eggse"} Stream))
+ (def a-dict @"d3:cow3:moo4:spam4:eggse")
  (is (= {"cow" "moo" "spam" "eggs"} (bencodobi/decode a-dict)) "decode a dictionary"))
 
 
 (deftest decode-nested-coll
- (def a-nested-coll (table/setproto @{:content @"d4:spaml1:a1:bee"} Stream))
+ (def a-nested-coll @"d4:spaml1:a1:bee")
  (is (= {"spam" ["a" "b"]} (bencodobi/decode a-nested-coll)) "decode a nested collection"))
 
 

--- a/test/iostream.janet
+++ b/test/iostream.janet
@@ -1,13 +1,23 @@
 (import testament :prefix "" :exit true)
 (import ../src/iostream :as iostream)
 
+
 (defn stream [source]
   (table/setproto @{:source source} iostream/IOStream))
+
 
 (deftest read-buffer
   (def output @"")
   (def input (stream @"hello"))
   (:read input 1 output)
-  (is (= "h" (string output))))
+  (is (= "h" (string output)) "read first byte from a buffer"))
+
+
+(deftest read-string
+  (def output @"")
+  (def input (stream "hello"))
+  (:read input 1 output)
+  (is (= "h" (string output)) "read first byte from a string"))
+
 
 (run-tests!)

--- a/test/iostream.janet
+++ b/test/iostream.janet
@@ -23,7 +23,7 @@
 (deftest read-too-much
   (def output @"")
   (def input (stream "hello"))
-  (is (thrown? (:read input 6 output))))
+  (is (thrown? (:read input 6 output)) "read more than in stream"))
 
 
 (run-tests!)

--- a/test/iostream.janet
+++ b/test/iostream.janet
@@ -1,0 +1,13 @@
+(import testament :prefix "" :exit true)
+(import ../src/iostream :as iostream)
+
+(defn stream [source]
+  (table/setproto @{:source source} iostream/IOStream))
+
+(deftest read-buffer
+  (def output @"")
+  (def input (stream @"hello"))
+  (:read input 1 output)
+  (is (= "h" (string output))))
+
+(run-tests!)

--- a/test/iostream.janet
+++ b/test/iostream.janet
@@ -1,29 +1,43 @@
 (import testament :prefix "" :exit true)
-(import ../src/iostream :as iostream)
+(import ../src/iostream :as io)
 
 
-(defn stream [source]
-  (table/setproto @{:source source} iostream/IOStream))
+(deftest forget-stream
+  (def output @"")
+  (def input @"hello")
+  (is (thrown? (:read input 1 output)) "forget to create a stream from a buffer"))
+
+
+(deftest read-file
+  (def file (file/temp))
+  (file/write file "hello")
+  (file/seek file :set 0)
+  (def output @"")
+  (def input (io/stream file))
+  (:read input 1 output)
+  (file/close file)
+  (is (= "h" (string output)) "read from a file"))
 
 
 (deftest read-buffer
   (def output @"")
-  (def input (stream @"hello"))
+  (def input (io/stream @"hello"))
   (:read input 1 output)
   (is (= "h" (string output)) "read first byte from a buffer"))
 
 
 (deftest read-string
   (def output @"")
-  (def input (stream "hello"))
+  (def input (io/stream "hello"))
   (:read input 1 output)
   (is (= "h" (string output)) "read first byte from a string"))
 
 
 (deftest read-too-much
   (def output @"")
-  (def input (stream "hello"))
-  (is (thrown? (:read input 6 output)) "read more than in stream"))
+  (def input (io/stream "hello"))
+  (:read input 6 output)
+  (is (= "hello" (string output)) "read more than in stream"))
 
 
 (run-tests!)

--- a/test/iostream.janet
+++ b/test/iostream.janet
@@ -2,10 +2,10 @@
 (import ../src/iostream :as io)
 
 
-(deftest forget-stream
+(deftest forget-reader
   (def output @"")
   (def input @"hello")
-  (is (thrown? (:read input 1 output)) "forget to create a stream from a buffer"))
+  (is (thrown? (:read input 1 output)) "forget to create a reader from a buffer"))
 
 
 (deftest read-file
@@ -13,7 +13,7 @@
   (file/write file "hello")
   (file/seek file :set 0)
   (def output @"")
-  (def input (io/stream file))
+  (def input (io/reader file))
   (:read input 1 output)
   (file/close file)
   (is (= "h" (string output)) "read from a file"))
@@ -21,23 +21,23 @@
 
 (deftest read-buffer
   (def output @"")
-  (def input (io/stream @"hello"))
+  (def input (io/reader @"hello"))
   (:read input 1 output)
   (is (= "h" (string output)) "read first byte from a buffer"))
 
 
 (deftest read-string
   (def output @"")
-  (def input (io/stream "hello"))
+  (def input (io/reader "hello"))
   (:read input 1 output)
   (is (= "h" (string output)) "read first byte from a string"))
 
 
 (deftest read-too-much
   (def output @"")
-  (def input (io/stream "hello"))
+  (def input (io/reader "hello"))
   (:read input 6 output)
-  (is (= "hello" (string output)) "read more than in stream"))
+  (is (= "hello" (string output)) "read more than in reader"))
 
 
 (run-tests!)

--- a/test/iostream.janet
+++ b/test/iostream.janet
@@ -20,4 +20,10 @@
   (is (= "h" (string output)) "read first byte from a string"))
 
 
+(deftest read-too-much
+  (def output @"")
+  (def input (stream "hello"))
+  (is (thrown? (:read input 6 output))))
+
+
 (run-tests!)


### PR DESCRIPTION
This PR adds an IOReader table that is used by Bencodobi to wrap stream-like objects (e.g. strings, buffers, etc) so that they can be read with a consistent API.